### PR TITLE
use meanFA to generate meanFAmask

### DIFF
--- a/lib/skeletonize.py
+++ b/lib/skeletonize.py
@@ -142,7 +142,7 @@ Note: Replace all the above directories with absolute paths.\n\n''')
         if not args.templateMask:
             print('Creating template mask ...')
             args.templateMask= pjoin(args.statsDir, 'mean_FA_mask.nii.gz')
-            meanFAmaskData = (dynminFA > 0) * 1
+            meanFAmaskData = (meanFAdata > 0) * 1
             save_nifti(args.templateMask, meanFAmaskData.astype('uint8'), target.affine, target.header)
 
         else:


### PR DESCRIPTION
Use of dynminFA was a mistake so far. That means if there is a hole in one subject, that hole will remain in meanFA and subsequenty in projected skeletons.

One fix is to simply binarise the meanFA.

[ENIGMA protocol](https://enigma.ini.usc.edu/wp-content/uploads/DTI_Protocols/ENIGMA_TBSS_protocol_USC.pdf) (page 2, point 5) declares one voxel as 1 if it is >=0.9 i.e. 90% of the population has non-zero FA at that voxel.