### PR TITLE
fix: get_data() to get_fdata() to make it work with nibabel v5

### DIFF
--- a/lib/dti.py
+++ b/lib/dti.py
@@ -25,7 +25,7 @@ def dti(imgPath, maskPath, inPrefix, outPrefix):
 
         mask= load(maskPath)
         bvals, bvecs= read_bvals_bvecs(inPrefix + '.bval', inPrefix + '.bvec')
-        masked_vol = applymask(vol.get_data(), mask.get_data())
+        masked_vol = applymask(vol.get_fdata(), mask.get_fdata())
 
         gtab= gradient_table(bvals, bvecs)
         dtimodel= dipyDti.TensorModel(gtab, fit_method= cost_func)
@@ -66,8 +66,8 @@ def dti(imgPath, maskPath, inPrefix, outPrefix):
         copyfile(outPrefix+'_L1.nii.gz', outPrefix+'_AD.nii.gz')
 
         # RD
-        L2= load(outPrefix+'_L2.nii.gz').get_data()
-        L3= load(outPrefix+'_L3.nii.gz').get_data()
+        L2= load(outPrefix+'_L2.nii.gz').get_fdata()
+        L3= load(outPrefix+'_L3.nii.gz').get_fdata()
         rd= (L2+L3)/2.
 
         save_nifti(outPrefix + '_RD.nii.gz', rd, vol.affine, vol.header)

--- a/lib/dwiMask.py
+++ b/lib/dwiMask.py
@@ -14,7 +14,7 @@ def dwiMask(dwImg, outPrefix, median_radius, num_pass):
 
     # extract the first b0
     ind= np.where(bvals<50)[0][0]
-    _, mask= median_otsu(img.get_data()[...,ind], median_radius, num_pass)
+    _, mask= median_otsu(img.get_fdata()[...,ind], median_radius, num_pass)
 
     save_nifti(outPrefix+'_mask.nii.gz', mask.astype('uint8'), img.affine, img.header)
 

--- a/lib/fillHoles.py
+++ b/lib/fillHoles.py
@@ -9,14 +9,14 @@ def fillHoles(imgPath):
     with TemporaryDirectory() as tmpdir, local.cwd(tmpdir):
 
         img= load(imgPath)
-        data= img.get_data()
+        data= img.get_fdata()
 
         dataBin= (data>0.)*1
         save_nifti('bin.nii.gz', dataBin.astype('uint8'), affine=img.affine, hdr=img.header)
 
         fslmaths['bin.nii.gz', '-fillh', 'bin_filled.nii.gz'] & FG
 
-        dataBinFilled= load('bin_filled.nii.gz').get_data()
+        dataBinFilled= load('bin_filled.nii.gz').get_fdata()
 
         dataDiff= dataBinFilled - dataBin
 

--- a/lib/roi_analysis.py
+++ b/lib/roi_analysis.py
@@ -51,7 +51,7 @@ def average_labels(labels):
 def subject_stat(imgPath, c, modality, label2name, commonLabels, labelMap, roiDir, avgFlag):
 
     print('Creating ROI based statistics for', imgPath)
-    img= load(imgPath).get_data()
+    img= load(imgPath).get_fdata()
     _imgNonzero= img>0
 
     df= pd.DataFrame(columns= ['Tract','Average','nVoxels'])
@@ -112,7 +112,7 @@ def subject_stat(imgPath, c, modality, label2name, commonLabels, labelMap, roiDi
 
 def roi_analysis(imgs, cases, args, roiDir, N_CPU):
 
-    intLabels = load(args.labelMap).get_data()
+    intLabels = load(args.labelMap).get_fdata()
     label2name = parse_labels(np.unique(intLabels)[1:], args.lut)
     commonLabels= average_labels(label2name.values())
 

--- a/lib/skeletonize.py
+++ b/lib/skeletonize.py
@@ -54,7 +54,7 @@ def calc_mean(imgs, shape):
     cumsumFA= np.zeros(shape, dtype= 'float32')
     consecutiveFA= np.inf*np.ones((2,shape[0],shape[1],shape[2]))
     for i, imgPath in enumerate(imgs):
-        data= load(imgPath).get_data().clip(min= 0.)
+        data= load(imgPath).get_fdata().clip(min= 0.)
         cumsumFA+= data
         
         consecutiveFA[0,: ]= data
@@ -81,7 +81,7 @@ def skeletonize(imgs, args, warpDir, skelDir, miFile):
         # made it optional with --qc flag
         allFAdata= np.zeros((L,X,Y,Z), dtype= 'float32')
         for i, c in enumerate(cases):
-            allFAdata[i,: ]= load(pjoin(warpDir, f'{c}_{args.modality}_to_target.nii.gz')).get_data()
+            allFAdata[i,: ]= load(pjoin(warpDir, f'{c}_{args.modality}_to_target.nii.gz')).get_fdata()
 
         allFA= pjoin(args.statsDir, f'all_{args.modality}.nii.gz')
         save_nifti(allFA, np.moveaxis(allFAdata, 0, -1), target.affine, target.header)
@@ -146,7 +146,7 @@ Note: Replace all the above directories with absolute paths.\n\n''')
             save_nifti(args.templateMask, meanFAmaskData.astype('uint8'), target.affine, target.header)
 
         else:
-            meanFAmaskData= load(args.templateMask).get_data()
+            meanFAmaskData= load(args.templateMask).get_fdata()
 
 
         meanFAdata = meanFAdata * meanFAmaskData
@@ -223,7 +223,7 @@ Note: Replace all the above directories with absolute paths.\n\n''')
         # this loop has been moved out of multiprocessing block to prevent memroy error
         allFAskeletonizedData= np.zeros((L, X, Y, Z), dtype= 'float32')
         for i,c in enumerate(cases):
-            allFAskeletonizedData[i,: ]= load(pjoin(skelDir, f'{c}_{args.modality}_to_target_skel.nii.gz')).get_data()
+            allFAskeletonizedData[i,: ]= load(pjoin(skelDir, f'{c}_{args.modality}_to_target_skel.nii.gz')).get_fdata()
 
         save_nifti(allFAskeletonized, np.moveaxis(allFAskeletonizedData, 0, -1), target.affine, target.header)
         print(f'Created {allFAskeletonized} sequenced according to {args.caselist}')


### PR DESCRIPTION
Nibabel was updated to v5 yesterday, and `get_data()` attribute is deprecated. Since the fresh install of `pnlbwh/TBSS` will install the most recent `nibabel`, we need to change `get_data()` to `get_fdata()`.